### PR TITLE
TextArea: Added missing getter innerPaddingBottom.

### DIFF
--- a/source/feathers/controls/TextArea.as
+++ b/source/feathers/controls/TextArea.as
@@ -1451,8 +1451,18 @@ package feathers.controls
 
 		/**
 		 * @private
+		 * This was accidentally named wrong. It is included for temporary
+		 * backward compatibility.
 		 */
 		public function get paddinnerPaddingBottomingBottom():Number
+		{
+			return this._innerPaddingBottom;
+		}
+		
+		/**
+		 * @private
+		 */
+		public function get innerPaddingBottom():Number
 		{
 			return this._innerPaddingBottom;
 		}


### PR DESCRIPTION
The existing getter is incorrectly (and amusingly) named paddinnerPaddingBottomingBottom.