### PR TITLE
Parallel: createParallelEffectWithEasing()

### DIFF
--- a/source/feathers/motion/Parallel.as
+++ b/source/feathers/motion/Parallel.as
@@ -37,5 +37,24 @@ package feathers.motion
 				return new ParallelEffectContext(target, rest);
 			};
 		}
+
+		/**
+		 * Creates an effect function that combines multiple effect functions
+		 * that will play at the same time, in parallel. The ease function 
+		 * will apply to the full duration of the effect, which will be the 
+		 * longest duration of the parallel effects.
+		 *
+		 * @productversion Feathers 3.5.0
+		 */
+		public static function createParallelEffectWithEasing(ease:Object, effect1:Function, effect2:Function, ...rest:Array):Function
+		{
+			//the order doesn't matter, so just add them at the end
+			rest[rest.length] = effect1;
+			rest[rest.length] = effect2;
+			return function(target:DisplayObject):IEffectContext
+			{
+				return new ParallelEffectContext(target, rest, ease);
+			};
+		}
 	}
 }

--- a/source/feathers/motion/effectClasses/ParallelEffectContext.as
+++ b/source/feathers/motion/effectClasses/ParallelEffectContext.as
@@ -21,7 +21,7 @@ package feathers.motion.effectClasses
 		/**
 		 * Constructor.
 		 */
-		public function ParallelEffectContext(target:DisplayObject, functions:Array)
+		public function ParallelEffectContext(target:DisplayObject, functions:Array, transition:Object = null)
 		{
 			var duration:Number = 0;
 			var count:int = functions.length;
@@ -36,7 +36,7 @@ package feathers.motion.effectClasses
 					duration = contextDuration;
 				}
 			}
-			super(target, duration);
+			super(target, duration, transition);
 		}
 
 		/**


### PR DESCRIPTION
The current Parallel.createParallelEffect() doesn't support easing/transitions, so added new createParallelEffectWithEasing(), which applies an easing function across the entire length of the parallel effect.

Josh, please let me know of any changes you would like me to make.